### PR TITLE
Fix/typesupport override

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,7 @@
-module(name = "com_github_mvukov_rules_ros2", version = "2.0.0.eddy.1")
+module(
+    name = "com_github_mvukov_rules_ros2",
+    version = "2.0.0.eddy.1",
+)
 
 bazel_dep(name = "asio", version = "1.31.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
@@ -28,9 +31,9 @@ bazel_dep(name = "zstd", version = "1.5.6")
 
 bazel_dep(name = "googletest", version = "1.15.2", dev_dependency = True)
 
-bazel_dep(name = "ros2_rosidl", version = "4.6.4.2.ge218840.iw.1")
-bazel_dep(name = "ros2_rosidl_typesupport", version = "3.2.2.iw.1")
-bazel_dep(name = "ros2_rosidl_python", version = "0.22.0.iw.1")
+bazel_dep(name = "ros2_rosidl", version = "4.6.4-3-g5d91679.iw.1")
+bazel_dep(name = "ros2_rosidl_typesupport", version = "3.2.2-1-gb43c945.iw.1")
+bazel_dep(name = "ros2_rosidl_python", version = "0.22.0-1-gf016c30.iw.1")
 # bazel_dep(name = "ros2_ament_cmake_ros", version = "0.10.0.iw.1")
 # bazel_dep(name = "ros2_launch_ros", version = "0.19.7.iw.1")
 # bazel_dep(name = "ros2cli", version = "0.18.10.iw.1")

--- a/ros2/interfaces.bzl
+++ b/ros2/interfaces.bzl
@@ -256,13 +256,17 @@ def run_generator(
         extra_inputs = [],
         type_description_tuples = [],
         include_paths = [],
-        out_snake_case_stemed = True):
+        out_snake_case_stemed = True,
+        output_dir_suffix = None):
     generator_templates = generator_templates[DefaultInfo].files.to_list()
 
     generator_arguments_file = ctx.actions.declare_file(
         "{}/{}_args.json".format(package_name, generator.basename),
     )
     output_dir = generator_arguments_file.dirname
+
+    if output_dir_suffix:
+        output_dir = "{}{}".format(output_dir, output_dir_suffix)
     generator_arguments = struct(
         package_name = package_name,
         idl_tuples = idl_tuples,
@@ -290,6 +294,8 @@ def run_generator(
         snake_case_stem = _to_snake_case(stem)
         if not out_snake_case_stemed:
             snake_case_stem = stem
+        if output_dir_suffix:
+            extension = output_dir_suffix + extension
         for t in output_mapping:
             relative_file = "{}/{}/{}".format(
                 package_name,
@@ -390,7 +396,7 @@ def _compile_cc_generated_code(
         srcs,
         hdrs,
         deps,
-        cc_include_dir,
+        cc_include_dirs,
         copts,
         target = None):
     cc_toolchain = find_cpp_toolchain(ctx)
@@ -417,7 +423,7 @@ def _compile_cc_generated_code(
         cc_toolchain = cc_toolchain,
         feature_configuration = feature_configuration,
         user_compile_flags = copts,
-        system_includes = [cc_include_dir],
+        system_includes = cc_include_dirs,
         srcs = srcs,
         public_hdrs = hdrs,
         compilation_contexts = compilation_contexts,
@@ -488,6 +494,7 @@ def _c_generator_aspect_impl(target, ctx):
         ],
         mnemonic = "Ros2IdlTypeSupportC",
         progress_message = "Generating C type support for %{label}",
+        output_dir_suffix = "/c/",
     )
 
     typesupport_introspection_outputs, _ = run_generator(
@@ -515,7 +522,7 @@ def _c_generator_aspect_impl(target, ctx):
         srcs = srcs,
         hdrs = hdrs,
         deps = ctx.attr._c_deps,
-        cc_include_dir = cc_include_dir,
+        cc_include_dirs = [cc_include_dir],
         copts = ctx.attr._c_copts,
     )
 
@@ -614,9 +621,7 @@ _INTERFACE_GENERATOR_CPP_OUTPUT_MAPPING = [
     "detail/%s__type_support.hpp",
 ]
 
-_TYPESUPPORT_GENERATOR_CPP_OUTPUT_MAPPING = [
-    "%s__type_support.cpp",
-]
+_TYPESUPPORT_GENERATOR_CPP_OUTPUT_MAPPING = ["%s__type_support.cpp"]
 
 _TYPESUPPORT_INTROSPECION_GENERATOR_CPP_OUTPUT_MAPPING = [
     "detail/%s__rosidl_typesupport_introspection_cpp.hpp",
@@ -627,6 +632,22 @@ def _cpp_generator_aspect_impl(target, ctx):
     package_name = target.label.name
     srcs = target[Ros2InterfaceInfo].info.srcs
     adapter = target[IdlAdapterAspectInfo]
+
+    c_interface_outputs, c_cc_include_dir = run_generator(
+        ctx,
+        srcs,
+        package_name,
+        adapter.idl_tuples,
+        adapter.idl_files,
+        ctx.executable._c_interface_generator,
+        ctx.attr._c_interface_templates,
+        _INTERFACE_GENERATOR_C_OUTPUT_MAPPING,
+        visibility_control_template = ctx.file._c_interface_visibility_control_template,
+        mnemonic = "Ros2IdlGeneratorC",
+        progress_message = "Generating C IDL interfaces for %{label}",
+        extra_inputs = adapter.type_description_outputs,
+        type_description_tuples = adapter.type_description_tuples,
+    )
 
     interface_outputs, cc_include_dir = run_generator(
         ctx,
@@ -658,6 +679,7 @@ def _cpp_generator_aspect_impl(target, ctx):
         ],
         mnemonic = "Ros2IdlTypeSupportCpp",
         progress_message = "Generating C++ type support for %{label}",
+        output_dir_suffix = "/cpp/",
     )
 
     typesupport_introspection_outputs, _ = run_generator(
@@ -673,7 +695,7 @@ def _cpp_generator_aspect_impl(target, ctx):
         progress_message = "Generating C++ type introspection support for %{label}",
     )
 
-    all_outputs = interface_outputs + typesupport_outputs + typesupport_introspection_outputs
+    all_outputs = c_interface_outputs + interface_outputs + typesupport_outputs + typesupport_introspection_outputs
     hdrs = _get_hdrs(all_outputs)
     srcs = _get_srcs(all_outputs)
 
@@ -684,7 +706,7 @@ def _cpp_generator_aspect_impl(target, ctx):
         srcs = srcs,
         hdrs = hdrs,
         deps = ctx.attr._cpp_deps,
-        cc_include_dir = cc_include_dir,
+        cc_include_dirs = [c_cc_include_dir, cc_include_dir],
         copts = ctx.attr._cpp_copts,
     )
 
@@ -699,6 +721,18 @@ cpp_generator_aspect = aspect(
     implementation = _cpp_generator_aspect_impl,
     attr_aspects = ["deps"],
     attrs = {
+        "_c_interface_generator": attr.label(
+            default = Label("@ros2_rosidl//:rosidl_generator_c_app"),
+            executable = True,
+            cfg = "exec",
+        ),
+        "_c_interface_templates": attr.label(
+            default = Label("@ros2_rosidl//:rosidl_generator_c_templates"),
+        ),
+        "_c_interface_visibility_control_template": attr.label(
+            default = Label("@ros2_rosidl//:rosidl_generator_c/resource/rosidl_generator_c__visibility_control.h.in"),
+            allow_single_file = True,
+        ),
         "_interface_generator": attr.label(
             default = Label("@ros2_rosidl//:rosidl_generator_cpp_app"),
             executable = True,
@@ -822,7 +856,7 @@ def _py_generator_aspect_impl(target, ctx):
         srcs = cc_srcs,
         hdrs = [],
         deps = ctx.attr._py_ext_c_deps,
-        cc_include_dir = cc_include_dir,
+        cc_include_dirs = [cc_include_dir],
         copts = ctx.attr._py_ext_c_copts,
         target = target,
     )

--- a/ros2/interfaces.bzl
+++ b/ros2/interfaces.bzl
@@ -245,13 +245,17 @@ def run_generator(
         extra_inputs = [],
         type_description_tuples = [],
         include_paths = [],
-        out_snake_case_stemed = True):
+        out_snake_case_stemed = True,
+        output_dir_suffix = None):
     generator_templates = generator_templates[DefaultInfo].files.to_list()
 
     generator_arguments_file = ctx.actions.declare_file(
         "{}/{}_args.json".format(package_name, generator.basename),
     )
     output_dir = generator_arguments_file.dirname
+
+    if output_dir_suffix:
+        output_dir = "{}{}".format(output_dir, output_dir_suffix)
     generator_arguments = struct(
         package_name = package_name,
         idl_tuples = idl_tuples,
@@ -279,6 +283,8 @@ def run_generator(
         snake_case_stem = _to_snake_case(stem)
         if not out_snake_case_stemed:
             snake_case_stem = stem
+        if output_dir_suffix:
+            extension = output_dir_suffix + extension
         for t in output_mapping:
             relative_file = "{}/{}/{}".format(
                 package_name,
@@ -379,7 +385,7 @@ def _compile_cc_generated_code(
         srcs,
         hdrs,
         deps,
-        cc_include_dir,
+        cc_include_dirs,
         copts,
         target = None):
     cc_toolchain = find_cpp_toolchain(ctx)
@@ -406,7 +412,7 @@ def _compile_cc_generated_code(
         cc_toolchain = cc_toolchain,
         feature_configuration = feature_configuration,
         user_compile_flags = copts,
-        system_includes = [cc_include_dir],
+        system_includes = cc_include_dirs,
         srcs = srcs,
         public_hdrs = hdrs,
         compilation_contexts = compilation_contexts,
@@ -477,6 +483,7 @@ def _c_generator_aspect_impl(target, ctx):
         ],
         mnemonic = "Ros2IdlTypeSupportC",
         progress_message = "Generating C type support for %{label}",
+        output_dir_suffix = "/c/",
     )
 
     typesupport_introspection_outputs, _ = run_generator(
@@ -504,7 +511,7 @@ def _c_generator_aspect_impl(target, ctx):
         srcs = srcs,
         hdrs = hdrs,
         deps = ctx.attr._c_deps,
-        cc_include_dir = cc_include_dir,
+        cc_include_dirs = [cc_include_dir],
         copts = ctx.attr._c_copts,
     )
 
@@ -603,9 +610,7 @@ _INTERFACE_GENERATOR_CPP_OUTPUT_MAPPING = [
     "detail/%s__type_support.hpp",
 ]
 
-_TYPESUPPORT_GENERATOR_CPP_OUTPUT_MAPPING = [
-    "%s__type_support.cpp",
-]
+_TYPESUPPORT_GENERATOR_CPP_OUTPUT_MAPPING = ["%s__type_support.cpp"]
 
 _TYPESUPPORT_INTROSPECION_GENERATOR_CPP_OUTPUT_MAPPING = [
     "detail/%s__rosidl_typesupport_introspection_cpp.hpp",
@@ -616,6 +621,22 @@ def _cpp_generator_aspect_impl(target, ctx):
     package_name = target.label.name
     srcs = target[Ros2InterfaceInfo].info.srcs
     adapter = target[IdlAdapterAspectInfo]
+
+    c_interface_outputs, c_cc_include_dir = run_generator(
+        ctx,
+        srcs,
+        package_name,
+        adapter.idl_tuples,
+        adapter.idl_files,
+        ctx.executable._c_interface_generator,
+        ctx.attr._c_interface_templates,
+        _INTERFACE_GENERATOR_C_OUTPUT_MAPPING,
+        visibility_control_template = ctx.file._c_interface_visibility_control_template,
+        mnemonic = "Ros2IdlGeneratorC",
+        progress_message = "Generating C IDL interfaces for %{label}",
+        extra_inputs = adapter.type_description_outputs,
+        type_description_tuples = adapter.type_description_tuples,
+    )
 
     interface_outputs, cc_include_dir = run_generator(
         ctx,
@@ -647,6 +668,7 @@ def _cpp_generator_aspect_impl(target, ctx):
         ],
         mnemonic = "Ros2IdlTypeSupportCpp",
         progress_message = "Generating C++ type support for %{label}",
+        output_dir_suffix = "/cpp/",
     )
 
     typesupport_introspection_outputs, _ = run_generator(
@@ -662,7 +684,7 @@ def _cpp_generator_aspect_impl(target, ctx):
         progress_message = "Generating C++ type introspection support for %{label}",
     )
 
-    all_outputs = interface_outputs + typesupport_outputs + typesupport_introspection_outputs
+    all_outputs = c_interface_outputs + interface_outputs + typesupport_outputs + typesupport_introspection_outputs
     hdrs = _get_hdrs(all_outputs)
     srcs = _get_srcs(all_outputs)
 
@@ -673,7 +695,7 @@ def _cpp_generator_aspect_impl(target, ctx):
         srcs = srcs,
         hdrs = hdrs,
         deps = ctx.attr._cpp_deps,
-        cc_include_dir = cc_include_dir,
+        cc_include_dirs = [c_cc_include_dir, cc_include_dir],
         copts = ctx.attr._cpp_copts,
     )
 
@@ -688,6 +710,18 @@ cpp_generator_aspect = aspect(
     implementation = _cpp_generator_aspect_impl,
     attr_aspects = ["deps"],
     attrs = {
+        "_c_interface_generator": attr.label(
+            default = Label("@ros2_rosidl//:rosidl_generator_c_app"),
+            executable = True,
+            cfg = "exec",
+        ),
+        "_c_interface_templates": attr.label(
+            default = Label("@ros2_rosidl//:rosidl_generator_c_templates"),
+        ),
+        "_c_interface_visibility_control_template": attr.label(
+            default = Label("@ros2_rosidl//:rosidl_generator_c/resource/rosidl_generator_c__visibility_control.h.in"),
+            allow_single_file = True,
+        ),
         "_interface_generator": attr.label(
             default = Label("@ros2_rosidl//:rosidl_generator_cpp_app"),
             executable = True,
@@ -811,7 +845,7 @@ def _py_generator_aspect_impl(target, ctx):
         srcs = cc_srcs,
         hdrs = [],
         deps = ctx.attr._py_ext_c_deps,
-        cc_include_dir = cc_include_dir,
+        cc_include_dirs = [cc_include_dir],
         copts = ctx.attr._py_ext_c_copts,
         target = target,
     )

--- a/ros2/interfaces.bzl
+++ b/ros2/interfaces.bzl
@@ -129,7 +129,7 @@ def _idl_adapter_aspect_impl(target, ctx):
     extra_inputs = []
     for dep in deps_labels:
         dep_name = dep[Ros2InterfaceInfo].name
-        dep_bindir = "{}/{}{}".format(ctx.bin_dir.path, _artifact_base_path(ctx.label.repo_name), dep_name)
+        dep_bindir = "{}/{}{}".format(ctx.bin_dir.path, _artifact_base_path(dep.label.repo_name), dep_name)
         deps_include_paths.append("{}:{}".format(dep_name, dep_bindir))
         extra_inputs.extend(dep[IdlAdapterAspectInfo].type_description_outputs)
 

--- a/ros2/interfaces.bzl
+++ b/ros2/interfaces.bzl
@@ -257,16 +257,17 @@ def run_generator(
         type_description_tuples = [],
         include_paths = [],
         out_snake_case_stemed = True,
-        output_dir_suffix = None):
+        output_dir_suffix = ""):
     generator_templates = generator_templates[DefaultInfo].files.to_list()
 
+    mapped_suffix = ""
+    if output_dir_suffix != "":
+        mapped_suffix = output_dir_suffix + package_name
     generator_arguments_file = ctx.actions.declare_file(
-        "{}/{}_args.json".format(package_name, generator.basename),
+        "{}{}/{}_args.json".format(package_name, mapped_suffix, generator.basename),
     )
     output_dir = generator_arguments_file.dirname
 
-    if output_dir_suffix:
-        output_dir = "{}{}".format(output_dir, output_dir_suffix)
     generator_arguments = struct(
         package_name = package_name,
         idl_tuples = idl_tuples,
@@ -295,7 +296,7 @@ def run_generator(
         if not out_snake_case_stemed:
             snake_case_stem = stem
         if output_dir_suffix:
-            extension = output_dir_suffix + extension
+            extension = output_dir_suffix + package_name + "/" + extension
         for t in output_mapping:
             relative_file = "{}/{}/{}".format(
                 package_name,
@@ -354,6 +355,7 @@ _INTERFACE_GENERATOR_C_OUTPUT_MAPPING = [
     "detail/%s__functions.h",
     "detail/%s__struct.h",
     "detail/%s__type_support.h",
+    "detail/%s__type_support.c",
 ]
 
 _TYPESUPPORT_GENERATOR_C_OUTPUT_MAPPING = ["%s__type_support.cpp"]
@@ -475,9 +477,10 @@ def _c_generator_aspect_impl(target, ctx):
         progress_message = "Generating C IDL interfaces for %{label}",
         extra_inputs = adapter.type_description_outputs,
         type_description_tuples = adapter.type_description_tuples,
+        output_dir_suffix = "/c_generator_c/",
     )
 
-    typesupport_outputs, _ = run_generator(
+    typesupport_outputs, cc_typesupport_include_dir = run_generator(
         ctx,
         srcs,
         package_name,
@@ -494,10 +497,10 @@ def _c_generator_aspect_impl(target, ctx):
         ],
         mnemonic = "Ros2IdlTypeSupportC",
         progress_message = "Generating C type support for %{label}",
-        output_dir_suffix = "/c/",
+        output_dir_suffix = "/c_typesupport_generator_c/",
     )
 
-    typesupport_introspection_outputs, _ = run_generator(
+    typesupport_introspection_outputs, cc_typesupport_introspection_include_dir = run_generator(
         ctx,
         srcs,
         package_name,
@@ -509,6 +512,7 @@ def _c_generator_aspect_impl(target, ctx):
         visibility_control_template = ctx.file._typesupport_introspection_visibility_control_template,
         mnemonic = "Ros2IdlTypeSupportIntrospectionC",
         progress_message = "Generating C type introspection support for %{label}",
+        output_dir_suffix = "/c_typesupport_introspection_generator_c/",
     )
 
     all_outputs = interface_outputs + typesupport_outputs + typesupport_introspection_outputs
@@ -522,7 +526,7 @@ def _c_generator_aspect_impl(target, ctx):
         srcs = srcs,
         hdrs = hdrs,
         deps = ctx.attr._c_deps,
-        cc_include_dirs = [cc_include_dir],
+        cc_include_dirs = [cc_include_dir, cc_typesupport_include_dir, cc_typesupport_introspection_include_dir],
         copts = ctx.attr._c_copts,
     )
 
@@ -647,6 +651,7 @@ def _cpp_generator_aspect_impl(target, ctx):
         progress_message = "Generating C IDL interfaces for %{label}",
         extra_inputs = adapter.type_description_outputs,
         type_description_tuples = adapter.type_description_tuples,
+        output_dir_suffix = "/cpp_generator_c/",
     )
 
     interface_outputs, cc_include_dir = run_generator(
@@ -660,9 +665,10 @@ def _cpp_generator_aspect_impl(target, ctx):
         _INTERFACE_GENERATOR_CPP_OUTPUT_MAPPING,
         mnemonic = "Ros2IdlGeneratorCpp",
         progress_message = "Generating C++ IDL interfaces for %{label}",
+        output_dir_suffix = "/cpp_generator_cpp/",
     )
 
-    typesupport_outputs, _ = run_generator(
+    typesupport_outputs, cc_typesupport_include_dir = run_generator(
         ctx,
         srcs,
         package_name,
@@ -679,10 +685,10 @@ def _cpp_generator_aspect_impl(target, ctx):
         ],
         mnemonic = "Ros2IdlTypeSupportCpp",
         progress_message = "Generating C++ type support for %{label}",
-        output_dir_suffix = "/cpp/",
+        output_dir_suffix = "/cpp_typesupport_generator_cpp/",
     )
 
-    typesupport_introspection_outputs, _ = run_generator(
+    typesupport_introspection_outputs, cc_typesupport_introspection_include_dir = run_generator(
         ctx,
         srcs,
         package_name,
@@ -693,6 +699,8 @@ def _cpp_generator_aspect_impl(target, ctx):
         _TYPESUPPORT_INTROSPECION_GENERATOR_CPP_OUTPUT_MAPPING,
         mnemonic = "Ros2IdlTypeSupportIntrospectionCpp",
         progress_message = "Generating C++ type introspection support for %{label}",
+        extra_inputs = c_interface_outputs,
+        output_dir_suffix = "/cpp_typesupport_introspection_generator_cpp/",
     )
 
     all_outputs = c_interface_outputs + interface_outputs + typesupport_outputs + typesupport_introspection_outputs
@@ -706,7 +714,7 @@ def _cpp_generator_aspect_impl(target, ctx):
         srcs = srcs,
         hdrs = hdrs,
         deps = ctx.attr._cpp_deps,
-        cc_include_dirs = [c_cc_include_dir, cc_include_dir],
+        cc_include_dirs = [c_cc_include_dir, cc_include_dir, cc_typesupport_include_dir, cc_typesupport_introspection_include_dir],
         copts = ctx.attr._cpp_copts,
     )
 


### PR DESCRIPTION
- Fix duplication in "%s_type_support.cpp" package name when trying to build c_ros2_interface() and cpp_ros2_interface() versions of the same message