### PR TITLE
ament: Add missing aspect to ros2_ament_setup

### DIFF
--- a/ros2/ament.bzl
+++ b/ros2/ament.bzl
@@ -6,6 +6,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     "@com_github_mvukov_rules_ros2//ros2:interfaces.bzl",
     "RosInterfaceInfo",
+    "c_generator_aspect",
     "cpp_generator_aspect",
     "idl_adapter_aspect",
     "type_description_aspect",
@@ -249,6 +250,7 @@ ros2_ament_setup = rule(
             aspects = [
                 idl_adapter_aspect,
                 type_description_aspect,
+                c_generator_aspect,
                 cpp_generator_aspect,
                 ros2_idl_plugin_aspect,
             ],


### PR DESCRIPTION
There can only be one possible aspect dependency graph for an aspect. Since we didn't include c_generator_aspect here, instead of doing:

```
idl_generator_aspect
|-> type_description_aspect
|   | `-> c_generator_aspect
`---`-----`-> cpp_generator_aspect
```

We skipped the C generator entirely and did:

```
idl_generator_aspect
|-> type_description_aspect
`---`-> cpp_generator_aspect
```

Which causes a conflict because Bazel sees these as two different actions.